### PR TITLE
Replace timegm()

### DIFF
--- a/htpdate.c
+++ b/htpdate.c
@@ -77,6 +77,14 @@ static int debug   = 0;
 static int logmode = 0;
 
 
+/* timegm() replacement */
+static long epoch(struct tm tm){
+    return(tm.tm_sec + tm.tm_min*60 + tm.tm_hour*3600 + tm.tm_yday*86400 +
+        (tm.tm_year-70)*31536000 + ((tm.tm_year-69)/4)*86400 -
+        ((tm.tm_year-1)/100)*86400 + ((tm.tm_year+299)/400)*86400);
+}
+
+
 /* Insertion sort is more efficient (and smaller) than qsort for small lists */
 static void insertsort(long a[], long length) {
     long i, j, value;
@@ -301,7 +309,7 @@ static long getHTTPdate(
 
             memset(&tm, 0, sizeof(struct tm));
             if (strptime(remote_time, "%d %b %Y %T", &tm) != NULL) {
-                timevalue.tv_sec = timegm(&tm);
+                timevalue.tv_sec = epoch(tm);
             } else {
                 printlog(1, "%s unknown time format", host);
             }


### PR DESCRIPTION
timegm() is not defined by any standard.

OpenBSD deprecated it, https://man.openbsd.org/OpenBSD-5.1/timegm.3

Implemented as described by https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap04.html#tag_04_16