### PR TITLE
Makefile: fix for cross compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ mandir = ${prefix}/share/man
 CC     ?= gcc
 CFLAGS += -Wall -std=c11 -pedantic -O2
 
-INSTALL = install -c
-STRIP   = strip -s
+INSTALL ?= install -c
+STRIP   ?= strip -s
 
 all: htpdate
 


### PR DESCRIPTION
When crosscompiling, instruments like strip or install can be already
defined with the toolchain paths, thus they shouldn't be overwritten by
the makefile.

Signed-off-by: Angelo Compagnucci <angelo.compagnucci@gmail.com>