### PR TITLE
htpdate: compile on non glibc toolchains

### DIFF
--- a/htpdate.c
+++ b/htpdate.c
@@ -52,7 +52,7 @@
 #include <pwd.h>
 #include <grp.h>
 
-#if defined BSD || defined __FreeBSD__
+#if defined __NetBSD__ || defined __FreeBSD__
 #define adjtimex ntp_adjtime
 #endif
 

--- a/htpdate.c
+++ b/htpdate.c
@@ -52,6 +52,10 @@
 #include <pwd.h>
 #include <grp.h>
 
+#if defined BSD || defined __FreeBSD__
+#define adjtimex ntp_adjtime
+#endif
+
 #ifdef ENABLE_HTTPS
 #include <openssl/ssl.h>
 #endif
@@ -523,7 +527,7 @@ static int htpdate_adjtimex(double drift) {
 
     /* Read current clock frequency */
     tmx.modes = 0;
-    ntp_adjtime(&tmx);
+    adjtimex(&tmx);
 
     /* Calculate new frequency */
     freq = (long)(65536e6 * drift);
@@ -538,7 +542,7 @@ static int htpdate_adjtimex(double drift) {
 
     /* Become root */
     swuid(0);
-    return(ntp_adjtime(&tmx));
+    return(adjtimex(&tmx));
 }
 
 


### PR DESCRIPTION
On most libc libraries, ntp_adjtime function or is an alias to
adjtimex, or it's missing entirely (musl, uclibc).
BSD libc instead does have this function and relies entirely
on ntp_adjtime.

Signed-off-by: Angelo Compagnucci <angelo.compagnucci@gmail.com>