### PR TITLE
htpdate: removing custom epoch function

### DIFF
--- a/htpdate.c
+++ b/htpdate.c
@@ -87,14 +87,6 @@ static int debug   = 0;
 static int logmode = 0;
 static int verifycert = 0;
 
-/* timegm() replacement */
-static long epoch(struct tm tm) {
-    return(tm.tm_sec + tm.tm_min*60 + tm.tm_hour*3600 + tm.tm_yday*86400 +
-        (tm.tm_year-70)*31536000 + ((tm.tm_year-69)/4)*86400 -
-        ((tm.tm_year-1)/100)*86400 + ((tm.tm_year+299)/400)*86400);
-}
-
-
 /* Insertion sort is more efficient (and smaller) than qsort for small lists */
 static void insertsort(double a[], long length) {
     long i, j;
@@ -208,7 +200,7 @@ static long getoffset(char remote_time[25]) {
     clock_gettime(CLOCK_REALTIME, &now);
     memset(&tm, 0, sizeof(struct tm));
     if (strptime(remote_time, "%d %b %Y %T", &tm) != NULL) {
-        timevalue.tv_sec = epoch(tm);
+        timevalue.tv_sec = mktime(&tm);
     } else {
         printlog(1, "unknown time format");
     }

--- a/htpdate.c
+++ b/htpdate.c
@@ -199,7 +199,7 @@ static long getoffset(char remote_time[25]) {
 
     clock_gettime(CLOCK_REALTIME, &now);
     memset(&tm, 0, sizeof(struct tm));
-    if (strptime(remote_time, "%d %b %Y %T", &tm) != NULL) {
+    if (strptime(remote_time, "%d %b %Y %T %Z", &tm) != NULL) {
         timevalue.tv_sec = mktime(&tm);
     } else {
         printlog(1, "unknown time format");


### PR DESCRIPTION
The epoch function return a wrong number of seconds, using the mktime
function librery instead.

Fixes #13:

$ htpdate -t -s -d https://google.com
google.com                443, 16 Jan 2022 18:04:01 GMT (89 ms) => 0
google.com                443, 16 Jan 2022 18:04:01 GMT (101 ms) => 0
google.com                443, 16 Jan 2022 18:04:01 GMT (67 ms) => 0
google.com                443, 16 Jan 2022 18:04:02 GMT (82 ms) => -1
when: 812500000, nap: -62500000
offset: 0.187500
Setting 0.188 seconds
Set time: Sat Jan  1 18:04:02 2022

Signed-off-by: Angelo Compagnucci <angelo.compagnucci@gmail.com>