### PR TITLE
Use pkg-config to determine openssl LDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ mandir = ${prefix}/share/man
 
 CC     ?= gcc
 CFLAGS += -Wall -std=c11 -pedantic -O2
+PKG_CONFIG ?= pkg-config
 
 INSTALL ?= install -c
 STRIP   ?= strip -s
@@ -14,7 +15,7 @@ htpdate: htpdate.c
 	$(CC) $(CFLAGS) -o htpdate htpdate.c
 
 https: htpdate.c
-	$(CC) $(CFLAGS) -DENABLE_HTTPS -o htpdate htpdate.c -lssl
+	$(CC) $(CFLAGS) -DENABLE_HTTPS -o htpdate htpdate.c  $(shell $(PKG_CONFIG) --libs libssl)
 
 install: all
 	$(STRIP) htpdate


### PR DESCRIPTION
Depending on its build configuration, openssl might not be compiled with dynamic zlib support, and programs that link against openssl need to link against zlib as well, as illustrated in this build failure:
http://autobuild.buildroot.net/results/ae9/ae946ca72238840b3eaa5fe823e8d620618f7462/

Signed-off-by: Titouan Christophe <titouan.christophe@railnova.eu>
[Retrieved (and slightly updated) from:
https://github.com/angeloc/htpdate/commit/72fcf9f82770e927e058a2eaa327d0eecb1e3c8d]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>