### PR TITLE
Log to standard error rather than standard output

### DIFF
--- a/htpdate.c
+++ b/htpdate.c
@@ -114,7 +114,7 @@ static void printlog(int is_error, char *format, ...) {
     if (logmode)
         syslog(is_error?LOG_WARNING:LOG_INFO, "%s", buf);
     else
-        fprintf(is_error?stderr:stdout, "%s\n", buf);
+        fprintf(stderr, "%s\n", buf);
 }
 
 
@@ -792,14 +792,14 @@ int main(int argc, char *argv[]) {
                 sw_uid = pw->pw_uid;
                 sw_gid = pw->pw_gid;
             } else {
-                printf("Unknown user %s\n", user);
+                fprintf(stderr, "Unknown user %s\n", user);
                 exit(1);
             }
             if (group != NULL) {
                 if ((gr = getgrnam(group)) != NULL) {
                     sw_gid = gr->gr_gid;
                 } else {
-                    printf("Unknown group %s\n", group);
+                    fprintf(stderr, "Unknown group %s\n", group);
                     exit(1);
                 }
             }


### PR DESCRIPTION
Due to stdio buffering, logging to the latter isn't very
useful (unless stdout is a tty, which for a daemon is a
marginal use case; and even then it's customary to log to
stderr).

(A concrete data point: running with '-F' under systemd, the
first batch of log messages got to the journal after 4
days.)

When at it, direct also the startup error messages to stderr.

(Leave -h and -v alone, printing to stdout seems to be
widespread there, although it's a mixed bag (double-checked
with a few BSD and GNU utilities).)