### PR TITLE
add name and pid to syslog output

### DIFF
--- a/htpdate.c
+++ b/htpdate.c
@@ -781,6 +781,7 @@ int main(int argc, char *argv[]) {
             break;
         case 'l':               /* log mode */
             logmode = 1;
+            openlog("htpdate",LOG_NDELAY||LOG_PID,LOG_DAEMON);
             break;
         case 'm':               /* minimum poll interval */
             if ((minsleep = (unsigned int)atoi(optarg)) <= 0) {


### PR DESCRIPTION
The syslog output for htpdate was being written  without the name and pid of the daemon,  so it was anonymous lines in the syslog output. with this chance, the log now correctly contain the name of the running process and its pid. 

2024-09-11T18:23:56.805151+00:00 00-00-00 htpdate[1825]: htpdate version 1.3.7 started
2024-09-11T18:23:58.950538+00:00 00-00-00 htpdate[1825]: Setting 4.125 seconds
2024-09-11T18:23:58.950869+00:00 00-00-00 htpdate[1825]: Set time: Wed Sep 11 18:24:03 2024
2024-09-11T18:54:03.000153+00:00 00-00-00 htpdate[1825]: sleep for 1800 s
2024-09-11T19:24:04.943582+00:00 00-00-00 htpdate[1825]: sleep for 3600 s`