### PR TITLE
htpdate.c: use fabs when checking offset is reasonable.

### DIFF
--- a/htpdate.c
+++ b/htpdate.c
@@ -939,7 +939,7 @@ int main(int argc, char *argv[]) {
             }
 
             /* Only include valid responses in timedelta[] */
-            if ((timelimit == NO_TIME_LIMIT && offset != ERR_TIMESTAMP) || (offset < timelimit && offset > -timelimit)) {
+            if ((timelimit == NO_TIME_LIMIT && offset != ERR_TIMESTAMP) || (fabs(offset) < timelimit)) {
                 timedelta[validtimes] = offset;
                 validtimes++;
             }


### PR DESCRIPTION
The current code does the following:

  (offset < timelimit && offset > -timelimit)

For reasons that I can't explain, on Ubuntu during automated tests on ppc64el, when offset is negative (-0.125), the second clause is false. I haven't been able to obtain the same behavior in a reproducer (different machines?) but using fabs() instead of the double comparison reliably fixes the issue. It is also in-line with recent use of fabs in the codebase.